### PR TITLE
Add batch file to build from cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Visual Studio files can be found in the `hellovulkan\build` directory.
 
 If you need to regenerate the Visual Studio files, open a command prompt in the `hellovulkan\premake` directory and run `..\..\premake\premake5.exe vs2015` (or `..\..\premake\premake5.exe vs2013` for Visual Studio 2013.)
 
+`build_msvc.bat` allows to build project from `cmd`.
+```cmd
+> build_msvc.bat
+> .\hellovulkan\bin\Main.exe
+```
+
 Vulkan also supports Linux&reg;, of course, and Premake can generate GNU Makefiles. However, at this time, the sample itself is Windows specific (because the helper code in Window.h/.cpp is Windows specific).
 
 Third-party software

--- a/build_msvc.bat
+++ b/build_msvc.bat
@@ -1,0 +1,28 @@
+@echo off
+
+if not defined DevEnvDir (
+    if "%VSWHERE%"=="" set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+)
+if not defined DevEnvDir (
+    for /f "usebackq tokens=*" %%i in (`call "%VSWHERE%" -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do (
+      set InstallDir=%%i
+    )
+)
+if not defined DevEnvDir (
+    if exist "%InstallDir%\VC\Auxiliary\Build\vcvars64.bat" (
+        call "%InstallDir%\VC\Auxiliary\Build\vcvars64.bat"
+    )
+)
+
+if not exist .\hellovulkan\bin mkdir .\hellovulkan\bin
+
+cl.exe /nologo /EHsc /Fo.\hellovulkan\bin\ /Fe.\hellovulkan\bin\ ^
+    /I %VULKAN_SDK%\Include ^
+    .\hellovulkan\src\Main.cpp ^
+    .\hellovulkan\src\VulkanSample.cpp ^
+    .\hellovulkan\src\VulkanQuad.cpp ^
+    .\hellovulkan\src\VulkanTexturedQuad.cpp ^
+    .\hellovulkan\src\Window.cpp ^
+    .\hellovulkan\src\ImageIO.cpp ^
+    .\hellovulkan\src\Utility.cpp ^
+    %VULKAN_SDK%\Lib\vulkan-1.lib

--- a/hellovulkan/src/ImageIO.cpp
+++ b/hellovulkan/src/ImageIO.cpp
@@ -27,6 +27,8 @@
 #include <wincodec.h>
 // for _com_error
 #include <comdef.h>
+// for runtime_error
+#include <stdexcept>
 
 #include "Utility.h"
 #define SAFE_WIC(expr) do {const auto r = expr; if (FAILED(r)) {_com_error err (r); OutputDebugString (err.ErrorMessage()); __debugbreak ();} } while (0,0)


### PR DESCRIPTION
* Fixed error `"runtime_error" is not a member of "std"` by including [\<stdexcept\>](https://en.cppreference.com/w/cpp/error/runtime_error)
* Added `build_msvc.bat` that you can launch from simple `cmd.exe`. It can automatically enable MSVC console tools if needed and build the project.